### PR TITLE
remove transitive edges

### DIFF
--- a/testdata/test.txtar
+++ b/testdata/test.txtar
@@ -5,6 +5,7 @@ cmp stdout go.md
 -- go-mod-graph.txt --
 github.com/example/foo github.com/example/bar
 github.com/example/bar github.com/example/baz
+github.com/example/foo github.com/example/baz
 github.com/example/foo github.com/example/baz/v2
 
 -- go.md --


### PR DESCRIPTION
Add a transitive reduction to eliminate noise from the output. These could easily be made optional or styled differently in the future, but they don't seem necessary for now.